### PR TITLE
Fix a bug BLEBoolCharacteristic not implemented (issue:01org#554)

### DIFF
--- a/libraries/CurieBLE/src/BLETypedCharacteristics.cpp
+++ b/libraries/CurieBLE/src/BLETypedCharacteristics.cpp
@@ -19,6 +19,10 @@
 
 #include "BLETypedCharacteristics.h"
 
+BLEBoolCharacteristic::BLEBoolCharacteristic(const char* uuid, unsigned char properties) :
+    BLETypedCharacteristic<bool>(uuid, properties) {
+}
+
 BLEByteCharacteristic::BLEByteCharacteristic(const char* uuid, unsigned char properties) :
     BLETypedCharacteristic<byte>(uuid, properties) {
 }


### PR DESCRIPTION
Solving that issue: https://github.com/01org/corelibs-arduino101/issues/554
BLEBoolCharacteristic not implemented, causing error: "undefined reference to `BLEBoolCharacteristic::BLEBoolCharacteristic(char const*, unsigned char)'".